### PR TITLE
feat: 适配mpvue-loader 1.1.0以上配置json

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -31,11 +31,8 @@ function genEntry(paths, pages, template) {
   const queue = pages.changed
     .filter(page => !page.native)
     .map((page) => {
-      const pageConfig = JSON.stringify({ config: page.config }, null, '  ');
-
       return writeFile(page.entry, template
-        .replace(/import App from .*/, `import App from '@/${page.path}'`)
-        .replace(/export default ?{[^]*}/, `export default ${pageConfig}`));
+        .replace(/import App from .*/, `import App from '@/${page.path}'`));
     });
 
   return Promise.all(queue).then(() => entry);

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,11 +76,31 @@ class MpvueEntry {
       // Support Webpack >= 4
       compiler.hooks.entryOption.tapAsync(this.constructor.name, entryOption.bind(this));
       compiler.hooks.afterEmit.tapAsync(this.constructor.name, MpvueEntry.afterEmit.bind(this));
+      compiler.hooks.emit.tapAsync(this.constructor.name, MpvueEntry.emit.bind(this));
     } else {
       // Support Webpack < 4
       compiler.plugin('entry-option', entryOption);
       compiler.plugin('after-emit', MpvueEntry.afterEmit);
+      compiler.plugin('emit', MpvueEntry.emit);
     }
+  }
+
+  /**
+   * add config json to assets
+   * @param {Object} compilation
+   * @param {Function} callback
+   */
+  static emit(compilation, callback) {
+    const queue = pages.changed
+      .filter(page => !page.native)
+      .forEach((page) => {
+        const pageConfig = JSON.stringify(page.config, null, '  ');
+        compilation.assets[`${page.path}.json`] = {
+          source: () => pageConfig,
+          size: () => pageConfig.length
+        };
+      });
+    callback()
   }
 
   /**


### PR DESCRIPTION
加了emit钩子，为每个page生成配置json
去除了旧版本用来将config写入js => export default 的代码
新方案应该可以兼容旧的