### PR TITLE
fix:添加vue&typescript单组件支持

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,7 +15,7 @@ function genEntry(paths, pages, template) {
   const entry = pages.formated
     .filter(page => !page.native)
     .reduce((result, page) => Object.assign({}, result, {
-      [page.path]: page.entry,
+      [page.path.replace(/\.vue$/, '')]: page.entry,
     }), { app: paths.main });
 
   pages.invalid
@@ -54,7 +54,7 @@ function genConfig(paths, pages, home) {
 
   app.pages = pages.formated
     .filter(page => !page.subPackage)
-    .map(page => page.path);
+    .map(page => page.path.replace(/\.vue$/, ''));
 
   app.subPackages = pages.formated
     .filter(page => page.subPackage)


### PR DESCRIPTION
vue的typescript单组件import必须添加.vue后缀
1. app.json中会出现.vue
2. webpack.entry中会出现.vue