### PR TITLE
fix: 修复 pages path 为父目录或 Windows 路径时生成 entryName 错误

### DIFF
--- a/lib/parser/pages.js
+++ b/lib/parser/pages.js
@@ -38,7 +38,7 @@ function parsePages(paths, oldPages = []) {
     .concat(formatedSubPackages)
     .map((page) => {
       const fdPage = typeof page === 'string' ? { path: page } : page;
-      const entryName = fdPage.path.replace(/\/(\w)/g, (match, $1) => $1.toUpperCase());
+      const entryName = fdPage.path.replace(/[.\\/]+(\w)/g, (match, $1) => $1.toUpperCase());
       fdPage.path = fdPage.path.replace(/^\//, '');
       fdPage.route = fdPage.route ? fdPage.route.replace(/^\//, '') : fdPage.path.replace(/\.vue$/, '');
       fdPage.root = fdPage.root && fdPage.root.replace(/^\/|\/$/g, '');


### PR DESCRIPTION
pages path 为父目录时，生成的 entry file 就不在 entry 目录中了